### PR TITLE
Fixes bug: trainSources in word-align.conf is incompatible with --name flag in pipeline.pl

### DIFF
--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -484,7 +484,7 @@ if (! defined $ALIGNMENT) {
 		s/<SOURCE>/$SOURCE.$chunkno/g;
 		s/<TARGET>/$TARGET.$chunkno/g;
 		s/<CHUNK>/$chunkno/g;
-
+		s/<TRAIN_DIR>/$DATA_DIRS{train}/g;
 		print TO;
 	  }
 	  close(TO);

--- a/scripts/training/templates/alignment/word-align.conf
+++ b/scripts/training/templates/alignment/word-align.conf
@@ -33,7 +33,7 @@ foreignSuffix	<SOURCE>
 englishSuffix	<TARGET>
 
 # Choose the training sources, which can either be directories or files that list files/directories
-trainSources data/train/splits/corpus
+trainSources <TRAIN_DIR>/splits/corpus
 sentences	 MAX
 testSources /dev/null
 overwriteExecDir true


### PR DESCRIPTION
In word-align.conf, the trainSource directory is hard-coded to train/splits/corpus .
However, this causes alignment to fail if pipeline.pl is called with the --name flag
because training data will be installed to train/<NAME> instead of train/.

This patch fixes this behavior by introducing a placeholder <TRAIN_DIR>,
which is replaced with the value of $DATA_DIR{train} inside of pipeline.py
