### PR TITLE
fixes to README

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,8 @@ The decoder output will load the language model and translation models defined
 in the configuration file, and will then decode the five sentences in the
 example file.
 
-You can enable multithreaded decoding with the -threads N flag:
+There are a variety of command line options that you can feed to Joshua.
+For example, you can enable multithreaded decoding with the -threads N flag:
 
     cat examples/example/test.in | $JOSHUA/joshua-decoder -c examples/example/joshua.config -threads 5
 
@@ -56,3 +57,12 @@ and so on.  For an example of parameters, see the Joshua configuration file
 template in $JOSHUA/scripts/training/templates/tune/joshua.config or the online
 documentation at joshua-decoder.org/4.0/decoder.html.  There is a wealth of
 information in the online documentation.
+
+After you have successfully run the decoding example above, we recommend that
+you take a look at the Joshua pipeline script, which allows you to do full 
+end-to-end training of a translation model.  It is stored in
+
+    $JOSHUA/examples
+
+ 
+

--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -5,21 +5,27 @@
 # --- and it allows jumping into arbitrary points of the pipeline. 
 
 my $JOSHUA;
+my $HADOOP;
 
 BEGIN {
   if (! exists $ENV{JOSHUA} || $ENV{JOSHUA} eq "" ||
+      ! exists $ENV{HADOOP} || $ENV{HADOOP} eq "" ||
       ! exists $ENV{JAVA_HOME} || $ENV{JAVA_HOME} eq "") {
-		print "Several environment variables must be set before running the pipeline.  Please set:\n";
-		print "* \$JOSHUA to the root of the Joshua source code.\n"
-				if (! exists $ENV{JOSHUA} || $ENV{JOSHUA} eq "");
-		print "* \$JAVA_HOME to the directory of your local java installation. \n"
-				if (! exists $ENV{JAVA_HOME} || $ENV{JAVA_HOME} eq "");
-		exit;
+                print "Several environment variables must be set before running the pipeline.  Please set:\n";
+                print "* \$JOSHUA to the root of the Joshua source code.\n"
+                                if (! exists $ENV{JOSHUA} || $ENV{JOSHUA} eq "");
+                print "* \$HADOOP to the directory of your local hadoop installation.\n"
+                                if (! exists $ENV{HADOOP} || $ENV{HADOOP} eq "");
+                print "* \$JAVA_HOME to the directory of your local java installation. \n"
+                                if (! exists $ENV{JAVA_HOME} || $ENV{JAVA_HOME} eq "");
+                exit;
   }
   $JOSHUA = $ENV{JOSHUA};
   unshift(@INC,"$JOSHUA/scripts/training/cachepipe");
   unshift(@INC,"$JOSHUA/lib");
 }
+
+
 
 use strict;
 use warnings;
@@ -32,7 +38,7 @@ use File::Temp qw/ :mktemp /;
 use CachePipe;
 # use Thread::Pool;
 
-my $HADOOP = $ENV{HADOOP};
+$HADOOP = $ENV{HADOOP};
 
 my $THRAX = "$JOSHUA/thrax";
 


### PR DESCRIPTION
I made minor corrections to the README for first time users. The compile command should be ant instead of ant jar, so that GIZA++ and KENLM get compiled. The example joshua.config file is in the tune/ subdir instead of the mert/ subdir.
