### PR TITLE
ignore files that are side effects of script testing

### DIFF
--- a/test/bn-en/packed/.gitignore
+++ b/test/bn-en/packed/.gitignore
@@ -1,1 +1,3 @@
 output
+diff
+output.bleu

--- a/test/decoder/regexp-grammar/.gitignore
+++ b/test/decoder/regexp-grammar/.gitignore
@@ -1,0 +1,2 @@
+diff
+output


### PR DESCRIPTION
files like `diff` and `output` and `output.bleu` that get created during testing of the decoder script should be ignored by git
