### PR TITLE
synchronous parsing: use Strings for node labels

### DIFF
--- a/src/joshua/decoder/hypergraph/GrammarBuilderWalkerFunction.java
+++ b/src/joshua/decoder/hypergraph/GrammarBuilderWalkerFunction.java
@@ -54,30 +54,15 @@ public class GrammarBuilderWalkerFunction implements WalkerFunction {
     }
   }
 
-  /*
-   * TODO: this can break silently and dangerously if we do try to parse sentences longer than the
-   * max length. If a sentence is longer than this length, then the IDs for labeled spans aren't
-   * guaranteed to be unique.
-   */
-  private static final int MAX_SENTENCE_LENGTH = 64;
-  public static final int MAX_NTS = 500000;
-
   private static int getLabelWithSpan(HGNode node) {
-    int x = node.i * MAX_SENTENCE_LENGTH;
-    x = (x + node.j) * MAX_NTS;
-    x = node.lhs - x;
-    if (x > 0) {
-      System.err.println("WARNING: integer overflow in node label!");
-      System.err.printf("lhs = %d, i = %d, j = %d, result = %d\n", node.lhs, node.i, node.j, x);
-    }
-    return x;
+    return Vocabulary.id(getLabelWithSpanAsString(node));
   }
 
   private static String getLabelWithSpanAsString(HGNode node) {
     String label = Vocabulary.word(node.lhs);
     String cleanLabel = reader.cleanNonTerminal(label);
     String unBracketedCleanLabel = cleanLabel.substring(1, cleanLabel.length() - 1);
-    return String.format("%d-%s-%d", node.i, unBracketedCleanLabel, node.j);
+    return String.format("[%d-%s-%d]", node.i, unBracketedCleanLabel, node.j);
   }
 
   private boolean nodeHasGoalSymbol(HGNode node) {
@@ -113,17 +98,21 @@ public class GrammarBuilderWalkerFunction implements WalkerFunction {
     // if this is a unary abstract rule, just return null
     // TODO: except glue rules!
     if (english.length == 1 && english[0] < 0 && !isGlue) return null;
-    int currNT = 1;
     int[] result = new int[english.length];
     for (int i = 0; i < english.length; i++) {
       int curr = english[i];
       if (!Vocabulary.nt(curr)) {
+				// If it's a terminal symbol, we just copy it into the new rule.
         result[i] = curr;
       } else {
+				// If it's a nonterminal, its value is -N, where N is the index
+				// of the nonterminal on the source side.
+				//
+				// That is, if we would call a nonterminal "[X,2]", the value of
+				// curr at this point is -2. And the tail node that it points at
+				// is #1 (since getTailNodes() is 0-indexed).
         int index = -curr - 1;
-        int label = getLabelWithSpan(edge.getTailNodes().get(index));
-        result[i] = label * 2 - currNT;
-        currNT++;
+        result[i] = getLabelWithSpan(edge.getTailNodes().get(index));
       }
     }
     // System.err.printf("source: %s\n", result);
@@ -132,13 +121,12 @@ public class GrammarBuilderWalkerFunction implements WalkerFunction {
 
   private static int[] getNewTargetFromSource(int[] source) {
     int[] result = new int[source.length];
+		int currNT = -1; // value to stick into NT slots
     for (int i = 0; i < source.length; i++) {
       result[i] = source[i];
       if (Vocabulary.nt(result[i])) {
-        int currNT = (Math.abs(result[i]) % 2) - 2;
         result[i] = currNT;
-        source[i] -= currNT;
-        source[i] /= 2;
+				currNT--;
       }
     }
     // System.err.printf("target: %s\n", result);

--- a/src/joshua/decoder/hypergraph/KBestExtractor.java
+++ b/src/joshua/decoder/hypergraph/KBestExtractor.java
@@ -661,11 +661,6 @@ public class KBestExtractor {
           if (lhs > 0) {
             System.err.printf("k-best: WARNING: rule LHS is greater than 0: %d\n", lhs);
           }
-          if (JoshuaConfiguration.parse) {
-            // hack to fix output labels in synchronous parsing
-            int max = GrammarBuilderWalkerFunction.MAX_NTS;
-            lhs = (lhs % max);
-          }
           sb.append(Vocabulary.word(lhs));
           if (includeAlign) {
             // append "{i-j}"


### PR DESCRIPTION
Matt claims that with forced decoding on the first pass, the
chart will be small enough that we don't need to do all this
hacky stuff when creating the second-pass grammar.

So instead we just do the simple thing, and add strings of the
form "i-X-j" to the Vocabulary and use them for the grammar.
Originally, we didn't explicitly build up the strings, which led
to ugly bookkeeping.
