### PR TITLE
Tree visualizer: add <s> and </s> to source

### DIFF
--- a/src/joshua/ui/tree_visualizer/browser/Browser.java
+++ b/src/joshua/ui/tree_visualizer/browser/Browser.java
@@ -96,7 +96,7 @@ public class Browser {
 		Scanner scanner = new Scanner(new File(path), "UTF-8");
 		while (scanner.hasNextLine()) {
 			TranslationInfo ti = new TranslationInfo();
-			ti.setSourceSentence(scanner.nextLine());
+			ti.setSourceSentence("<s> " + scanner.nextLine() + " </s>");
 			translations.add(ti);
 		}
 	}


### PR DESCRIPTION
The alignments from new Joshua output don't agree unless we
include start- and end-of-sentence symbols in the source sentence.
