### PR TITLE
Fixed the names of the feature function that are added: they must be con...

### DIFF
--- a/src/joshua/decoder/ff/ArityPhrasePenaltyFF.java
+++ b/src/joshua/decoder/ff/ArityPhrasePenaltyFF.java
@@ -41,7 +41,7 @@ public class ArityPhrasePenaltyFF extends StatelessFF {
   }
 
   public static String getFeatureName(){
-    return ARITY_PHRASE_PENALTY_NAME;
+    return ARITY_PHRASE_PENALTY_FF_NAME;
   }
   
   /**

--- a/src/joshua/decoder/ff/ArityPhrasePenaltyFF.java
+++ b/src/joshua/decoder/ff/ArityPhrasePenaltyFF.java
@@ -18,13 +18,14 @@ import joshua.corpus.Vocabulary;
  */
 public class ArityPhrasePenaltyFF extends StatelessFF {
 
+  private static final String ARITY_PHRASE_PENALTY_FF_NAME = "aritypenalty";
   // when the rule.arity is in the range, then this feature is activated
   private final int owner;
   private final int minArity;
   private final int maxArity;
 
   public ArityPhrasePenaltyFF(final FeatureVector weights, String argString) {
-    super(weights, "ArityPenalty", argString);
+    super(weights,ARITY_PHRASE_PENALTY_FF_NAME , argString);
 
     // Process the args for the owner, minimum, and maximum.
 
@@ -39,6 +40,10 @@ public class ArityPhrasePenaltyFF extends StatelessFF {
       System.err.println("WARNING: no weight found for feature '" + name + "'");
   }
 
+  public static String getFeatureName(){
+    return ARITY_PHRASE_PENALTY_NAME;
+  }
+  
   /**
    * Returns 1 if the arity penalty feature applies to the current rule.
    */

--- a/src/joshua/decoder/ff/OOVFF.java
+++ b/src/joshua/decoder/ff/OOVFF.java
@@ -21,12 +21,18 @@ import joshua.decoder.chart_parser.SourcePath;
 public class OOVFF extends StatelessFF {
   private int ownerID = -1;
 
+  private static String OOV_FF_NAME =  "oovpenalty";
+  
   public OOVFF(FeatureVector weights) {
-    super(weights, "OOVPenalty");
+    super(weights, OOV_FF_NAME);
 
     ownerID = Vocabulary.id("oov");
   }
 
+  public static String getFeatureName(){
+    return OOV_FF_NAME;
+  }
+  
   /**
    * OOV rules cover exactly one word, and such rules belong to a grammar whose owner is "oov". Each
    * OOV fires the OOVPenalty feature with a value of 1, so the cost is simply the weight, which was

--- a/src/joshua/decoder/ff/SourcePathFF.java
+++ b/src/joshua/decoder/ff/SourcePathFF.java
@@ -16,11 +16,17 @@ import joshua.decoder.hypergraph.HGNode;
  */
 public final class SourcePathFF extends StatelessFF {
 
+  private static String SOURCE_PATH_FF_NAME = "sourcepath";
+  
   /*
    * This is a single-value feature template, so we cache the weight here.
    */
   public SourcePathFF(FeatureVector weights) {
-    super(weights, "SourcePath", ""); // this sets name
+    super(weights, SOURCE_PATH_FF_NAME, ""); // this sets name
+  }
+  
+  public String getFeatureName(){
+    return SOURCE_PATH_FF_NAME;
   }
   
   @Override

--- a/src/joshua/decoder/ff/WordPenaltyFF.java
+++ b/src/joshua/decoder/ff/WordPenaltyFF.java
@@ -16,8 +16,14 @@ public final class WordPenaltyFF extends StatelessFF {
 
   private static final float OMEGA = -(float) Math.log10(Math.E); // -0.435
 
+  private static String WORD_PENALTY_FF_NAME = "wordpenalty";
+  
   public WordPenaltyFF(final FeatureVector weights) {
-    super(weights, "WordPenalty", "");
+    super(weights, WORD_PENALTY_FF_NAME, "");
+  }
+  
+  public static String getFeatureName(){
+    return WORD_PENALTY_FF_NAME;
   }
 
   @Override


### PR DESCRIPTION
...sistently lowercased for consistency

with the FeatureVector class and its weights table.

Lowercasing the feature fucntion names in the method  initializeFeatureFunctions()
in the Decoder.java class, but then still using uppercased feature names in the feature classes themselves
lead to inconsistency and nasty bugs were setting the weight of certain features like OOV and WordPenalty
had no effect. By also using the lowercased version in the constructors of these classes, this bug
is now fixed.

   modified:   src/joshua/decoder/ff/ArityPhrasePenaltyFF.java
   modified:   src/joshua/decoder/ff/OOVFF.java
   modified:   src/joshua/decoder/ff/SourcePathFF.java
   modified:   src/joshua/decoder/ff/WordPenaltyFF.java