### PR TITLE
Bugfix, was pulling number of features from feature map before generating it.

### DIFF
--- a/src/joshua/util/encoding/FeatureTypeAnalyzer.java
+++ b/src/joshua/util/encoding/FeatureTypeAnalyzer.java
@@ -140,13 +140,14 @@ public class FeatureTypeAnalyzer {
     BufferedOutputStream buf_stream = new BufferedOutputStream(new FileOutputStream(out_file));
     DataOutputStream out_stream = new DataOutputStream(buf_stream);
 
+    buildFeatureMap();
+    
     getIdEncoder().writeState(out_stream);
     out_stream.writeBoolean(labeled);
     out_stream.writeInt(types.size());
     for (int index = 0; index < types.size(); index++)
       types.get(index).encoder.writeState(out_stream);
 
-    buildFeatureMap();
     out_stream.writeInt(featureToType.size());
     for (int feature_id : featureToType.keySet()) {
       if (labeled)


### PR DESCRIPTION
This should fix an error in the establishing of the encoder for feature ids, which led to the packed grammar parsing garbage into the features, accidentally zero-ing all of them.
