### PR TITLE
Remove -static from Makefile test for Boost

### DIFF
--- a/src/joshua/decoder/ff/lm/kenlm/Makefile
+++ b/src/joshua/decoder/ff/lm/kenlm/Makefile
@@ -24,7 +24,7 @@ INSTALL=build_binary ngram_query
 
 #lmplz
 SHELL=bash
-ifeq ($(shell g++ -static -lboost_program_options-mt -lboost_thread-mt -x c++ - <<<'int main() {}' -o dummy && rm dummy && echo Boost),Boost)
+ifeq ($(shell g++ -lboost_program_options-mt -lboost_thread-mt -x c++ - <<<'int main() {}' -o dummy && rm dummy && echo Boost),Boost)
   $(info Detected Boost)
 LMPLZ=lm/builder/adjust_counts.o lm/builder/corpus_count.o lm/builder/initial_probabilities.o lm/builder/interpolate.o lm/builder/lmplz_main.o lm/builder/pipeline.o lm/builder/print.o util/stream/chain.o util/stream/io.o util/stream/line_input.o util/stream/multi_progress.o
 lmplz: $(CORE) $(HEADERS) $(LMPLZ)


### PR DESCRIPTION
Julia Neidert reported that systems without static glibc installed (the Stanford NLP cluster, apparently) will look for static -lm when compiling with -static.  This causes the Boost presence test to fail even when Boost is installed.
