### PR TITLE
joshua-188 Implement descriptions for all Ant tasks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -40,11 +40,12 @@
   <!-- ~~~~~ Init build task ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
   <!-- Create the build directory for compiled class files -->
-  <target name="init" depends="check-joshua-home, resolve, download-thrax, download-hadoop">
+  <target name="init" depends="check-joshua-home, resolve, download-thrax, download-hadoop" 
+    description="--> Check for environment variables, retrieve dependencies with ivy, download Thrax and Hadoop is required">
   </target>
 
   <!-- Check for environment variables -->
-  <target name="check-joshua-home">
+  <target name="check-joshua-home" description="--> Check for environment variables">
     <echo message="JOSHUA = ${JOSHUA} basedir = ${basedir}" />
     <!-- <if> -->
     <!--   <not> -->
@@ -57,7 +58,7 @@
   </target>
 
   <!-- Set git version -->
-  <target name="git-version" description="Store latest git commit ID">
+  <target name="git-version" description="--> Store latest git commit ID">
     <exec executable="git">
       <arg value="rev-parse"/>
       <arg value="--short"/>
@@ -65,16 +66,16 @@
     </exec>
   </target>
 
-  <target name="set-joshua-version" unless="env.JOSHUA_VERSION">
+  <target name="set-joshua-version" unless="env.JOSHUA_VERSION" description="--> Prompt user to set Joshua version environment variable">
     <fail message="Please set the $JOSHUA_VERSION environment variable." />
   </target>
 
-  <target name="set-java-home" unless="env.JAVA_HOME">
+  <target name="set-java-home" unless="env.JAVA_HOME" description="--> Prompt user to set JAVA_HOME environment variable">
     <fail message="Please set the $JAVA_HOME environment variable." />
     <!-- TODO: add suggestion to use /System/Library/Frameworks/JavaVM.framework/Home/ iff on OSX -->
   </target>
 
-  <target name="kenlm" depends="check-joshua-home">
+  <target name="kenlm" depends="check-joshua-home" description="--> 'Make' the kenlm sofrtware in ${src}/joshua/decoder/ff/lm/kenlm/">
     <exec executable="make">
       <arg value="-j" />
       <arg value="4" />
@@ -84,7 +85,7 @@
     </exec>
   </target>
 
-  <target name="giza" depends="check-joshua-home">
+  <target name="giza" depends="check-joshua-home" description="--> 'Make' the giza software in scripts/training/giza-pp/">
     <exec executable="make">
       <arg value="-j" />
       <arg value="4" />
@@ -107,7 +108,7 @@
     <!--       </exec> -->
   </target>
 
-  <target name="parallelize" depends="check-joshua-home">
+  <target name="parallelize" depends="check-joshua-home" description="--> 'Make' the parallelize software in scripts/training/parallelize/">
     <exec executable="make">
       <arg value="-j" />
       <arg value="4" />
@@ -116,7 +117,7 @@
     </exec>
   </target>
 
-  <target name="download-thrax" depends="check-joshua-home">
+  <target name="download-thrax" depends="check-joshua-home" description="--> Download the Thrax software">
     <exec executable="git">
       <arg value="submodule" />
       <arg value="init" />
@@ -127,7 +128,7 @@
     </exec>
   </target>
 
-  <target name="thrax" depends="check-joshua-home">
+  <target name="thrax" depends="check-joshua-home" description="--> Build Thrax">
     <subant buildpath="thrax">
       <property name="env.HADOOP" value="${lib}" />
       <property name="env.HADOOP_VERSION" value="0.20.203.0" />
@@ -138,7 +139,7 @@
 
   <!-- Download the hadoop tool tarball (not jar library), which gets used by
        pipeline.pl and test/hadoop/ -->
-  <target name="download-hadoop" depends="check-joshua-home">
+  <target name="download-hadoop" depends="check-joshua-home" description="--> Download the Hadoop software">
     <get
       src="http://archive.apache.org/dist/hadoop/core/hadoop-0.20.2/hadoop-0.20.2.tar.gz"
       dest="${JOSHUA}/lib"
@@ -156,7 +157,7 @@
 
   <!-- ~~~~~ Java build tasks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
-  <target name="all" depends="setup, jar, giza, kenlm, parallelize">
+  <target name="all" depends="setup, jar, giza, kenlm, parallelize" description="--> Default target Java build tasks">
   </target>
 
   <!-- The setup target does some downloading of files. These files
@@ -168,7 +169,7 @@
   </target>
 
   <!-- Compile the Java code. -->
-  <target name="java" depends="check-joshua-home">
+  <target name="java" depends="check-joshua-home" description="--> Compile the Java code">
     <mkdir dir="${build}" />
     <javac compiler="javac1.7" srcdir="${src}" destdir="${build}" classpathref="compile.all.classpath" debug="on" encoding="utf8" sourcepath="" includeantruntime="false">
       <!-- We nullify the sourcepath in order to disable Ant's usual resolution mechanism. This makes it an error for our basic code to call into code that has external dependencies, rather than auto-including those files and then having a classpath error. -->
@@ -181,7 +182,7 @@
   </target>
 
   <!-- Create a JAR file -->
-  <target name="jar" depends="java,check-joshua-home">
+  <target name="jar" depends="java,check-joshua-home" description="--> Create a JAR file of compiles classes">
     <jar destfile="${build}/joshua.jar" index="true">
       <fileset dir="${build}">
         <include name="**/*.class" />
@@ -192,7 +193,7 @@
     </jar>
   </target>
 
-  <target name="tree_visualizer" depends="java,check-joshua-home">
+  <target name="tree_visualizer" depends="java,check-joshua-home" description="--> Runs the Tree Visualizer software in examples/tree_visualizer/tree_visualizer.jar">
     <jar destfile="examples/tree_visualizer/tree_visualizer.jar" index="true">
       <zipgroupfileset dir="lib" includes="*.jar" />
       <fileset dir="${build}">
@@ -209,14 +210,14 @@
   </target>
 
   <!-- Create a versioned release -->
-  <target name="release" depends="set-joshua-version, devel-clean, init, thrax">
+  <target name="release" depends="set-joshua-version, devel-clean, init, thrax" description="--> Create a versioned release">
     <exec executable="./scripts/support/make-release.sh">
       <arg value="${env.JOSHUA_VERSION}" />
     </exec>
   </target>
 
   <!-- Create a JAR file of the source code -->
-  <target name="source-jar">
+  <target name="source-jar" description="--> Create a JAR file of the source code">
     <jar destfile="${build}/joshua-src.jar">
       <fileset dir="${build}">
         <include name="**/*.java" />
@@ -227,7 +228,7 @@
   <!-- ~~~~~ Cleaning tasks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
   <!-- Delete the compiled files -->
-  <target name="clean" depends="clean-thrax,clean-java">
+  <target name="clean" depends="clean-thrax,clean-java" description="--> Clean (remove) all build directories">
     <exec executable="make">
       <arg value="-C" />
       <arg value="scripts/training/giza-pp" />
@@ -243,7 +244,7 @@
   </target>
 
   <!-- Delete just the java files -->
-  <target name="clean-java">
+  <target name="clean-java" description="--> Delete just the java files">
     <delete verbose="true" quiet="true">
       <fileset dir="${build}">
         <include name="**/*.class" />
@@ -251,7 +252,7 @@
     </delete>
   </target>
 
-  <target name="clean-thrax">
+  <target name="clean-thrax" description="--> Delete just the thrax files">
       <delete verbose="true" quiet="true">
       <fileset dir="${thraxlib}">
         <include name="**/*.class"/>
@@ -260,7 +261,7 @@
   </target>
 
   <!-- EXPERIMENTAL: Delete *all* generated files -->
-  <target name="distclean" depends="clean">
+  <target name="distclean" depends="clean" description="--> EXPERIMENTAL: Delete *all* generated files">
     <!-- BUG: this doesn't delete empty folders (neither ${build} itself, nor the class dirs (the latter makes sense since we don't traverse them)) -->
     <delete verbose="true" quiet="true" includeEmptyDirs="true">
       <fileset dir="${build}">
@@ -292,7 +293,7 @@
 
   <!-- Delete *all* generated files,
        including files and directories not tracked by git -->
-  <target name="devel-clean">
+  <target name="devel-clean" description="--> Delete *all* generated files, including files and directories not tracked by git">
 
     <input
       message="WARNING: all untracked, ignored files will be removed. Continue? (y/n) "
@@ -314,7 +315,7 @@
   <!-- ~~~~~ Javadoc ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
   <!-- Compile the Javadocs into web pages -->
-  <target name="javadoc">
+  <target name="javadoc" description="--> Compile the Javadocs into web pages">
     <mkdir dir="${doc}" />
     <javadoc packagenames="joshua.*" classpath="${cli}" sourcepath="${src}" destdir="${doc}" author="true" version="true" charset="utf-8" overview="src/overview.html">
       <link href="http://docs.oracle.com/javase/7/docs/api/" />
@@ -327,13 +328,13 @@
   <taskdef uri="antlib:org.doxygen.tools" resource="org/doxygen/tools/antlib.xml" classpath="${lib}/ant-doxygen-1.6.1.jar" />
 
   <!-- Compile the Javadocs and Markdown documentation into web pages -->
-  <target name="documentation" depends="check-joshua-home">
+  <target name="documentation" depends="check-joshua-home" description="--> Compile the Javadocs and Markdown documentation into web pages">
     <doxygen:doxygen configFilename="${doc}/Doxyfile" />
   </target>
 
   <!-- ~~~~~ Tests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
-  <target name="test" depends="all">
+  <target name="test" depends="all" description="--> Run tests">
     <exec dir="test" executable="/bin/bash" failonerror="false">
       <arg line="run-all-tests.sh" />
     </exec>
@@ -347,13 +348,13 @@
 
   <!-- Compile the unit test code -->
   <!-- FIXME: why is this broken out from the 'test' target? -->
-  <target name="compile-tests" depends="java">
+  <target name="compile-tests" depends="java" description="--> Compile the unit test code">
     <javac compiler="javac1.5" srcdir="${test}/joshua/ui" destdir="${build}" classpath="${testng}:${build}" debug="on" encoding="utf8" />
   </target>
 
 
   <!-- Run the unit tests -->
-  <target name="testng" depends="all,compile-tests">
+  <target name="testng" depends="all,compile-tests" description="--> Run the unit tests">
     <testng classpath="${build}" sourcedir="${test}">
       <jvmarg value="-Dfile.encoding=UTF8" />
       <jvmarg value="-Xms256m" />
@@ -386,7 +387,7 @@
     <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true" skipexisting="true" />
   </target>
 
-  <target name="init-ivy" depends="download-ivy">
+  <target name="init-ivy" depends="download-ivy" description="--> Try to load and initialize Ivy here from Ivy Home">
     <!-- try to load ivy here from ivy home, in case the user has not already dropped
             it into ant's lib dir (note that the latter copy will always take precedence).
             We will not fail as long as local lib dir exists (it may be empty) and


### PR DESCRIPTION
When I invoke the task *ant -projecthelp* I get a nice message 
```
lmcgibbn@LMC-032857 /usr/local/joshua(master) $ ant -projecthelp
Buildfile: /usr/local/joshua/build.xml

Main targets:

 all                 --> Default target Java build tasks
 check-joshua-home   --> Check for environment variables
 clean               --> Clean (remove) all build directories
 clean-java          --> Delete just the java files
 clean-thrax         --> Delete just the thrax files
 compile-tests       --> Compile the unit test code
 devel-clean         --> Delete *all* generated files, including files and directories not tracked by git
 distclean           --> EXPERIMENTAL: Delete *all* generated files
 documentation       --> Compile the Javadocs and Markdown documentation into web pages
 download-hadoop     --> Download the Hadoop software
 download-thrax      --> Download the Thrax software
 git-version         --> Store latest git commit ID
 giza                --> 'Make' the giza software in scripts/training/giza-pp/
 init                --> Check for environment variables, retrieve dependencies with ivy, download Thrax and Hadoop is required
 init-ivy            --> Try to load and initialize Ivy here from Ivy Home
 jar                 --> Create a JAR file of compiles classes
 java                --> Compile the Java code
 javadoc             --> Compile the Javadocs into web pages
 kenlm               --> 'Make' the kenlm sofrtware in ${src}/joshua/decoder/ff/lm/kenlm/
 parallelize         --> 'Make' the parallelize software in scripts/training/parallelize/
 release             --> Create a versioned release
 resolve             --> retrieve dependencies with ivy
 set-java-home       --> Prompt user to set JAVA_HOME environment variable
 set-joshua-version  --> Prompt user to set Joshua version environment variable
 source-jar          --> Create a JAR file of the source code
 test                --> Run tests
 testng              --> Run the unit tests
 thrax               --> Build Thrax
 tree_visualizer     --> Runs the Tree Visualizer software in examples/tree_visualizer/tree_visualizer.jar
Default target: all
```