### PR TITLE
Ivy does not re-download artifacts that already exist

### DIFF
--- a/lib/ivysettings.xml
+++ b/lib/ivysettings.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0"?>
 <ivysettings >
-  <settings defaultResolver="maven" />
+  <settings defaultResolver="1" />
   <resolvers>
-    <chain name="maven" returnFirst="true">
-      <ibiblio name="central" m2compatible="true"/>
-      <ibiblio name="tools.gbif.org" m2compatible="true" root="http://tools.gbif.org/maven/repository/" />
-      <packager name="roundup" buildRoot="${env.JOSHUA}/lib/packager/build" resourceCache="${env.JOSHUA}/lib/cache">
-        <ivy pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/ivy.xml"/>
-        <artifact pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/packager.xml"/>
-      </packager>
+    <chain name="1">
+
+      <chain name="1">
+        <filesystem name="filesystem">
+          <ivy pattern="${ivy.settings.dir}/ivy.xml"/>
+          <artifact pattern="${ivy.settings.dir}/[artifact]-[revision].[ext]"/>
+        </filesystem>
+      </chain>
+
+      <chain name="maven">
+        <ibiblio name="central" m2compatible="true"/>
+        <ibiblio name="tools.gbif.org" m2compatible="true" root="http://tools.gbif.org/maven/repository/" />
+        <packager name="roundup" buildRoot="${env.JOSHUA}/lib/packager/build" resourceCache="${env.JOSHUA}/lib/cache">
+          <ivy pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/ivy.xml"/>
+          <artifact pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/packager.xml"/>
+        </packager>
+      </chain>
+
     </chain>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
Also, ivy shouldn't fail if there is no internet connection. This
prevents builds!

Would like ivy to download the first time, and then know it's done
so, not running any more for later runs (and not killing builds when
there is no internet connection).

Fixes #190