### PR TITLE
Parallel aligners

### DIFF
--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -786,16 +786,16 @@ if (! defined $ALIGNMENT) {
 
   # Start a parallel job on each core
   my @children = ();
-  my $chunk = 0
-  foreach my $core (1..$max_aligner_threads) {
-    if ($chunk < $lastchunk + 1) {
+  my $next_chunk = 0;
+  foreach my $core (1..$NUM_THREADS) {
+    if ($next_chunk < $lastchunk + 1) {
       my $child = fork();
       if (! $child) { # I am child
-          exec("echo $chunk | $aligner_cmd");
-          exit 0;
+        exec("echo $next_chunk | $aligner_cmd");
+        exit 0;
       }
       push @children, $child;
-      $chunk++;
+      $next_chunk++;
       next;
     }
   }
@@ -806,13 +806,13 @@ if (! defined $ALIGNMENT) {
     waitpid( $old_child, 0 );
     print "child finished\n";
 
-    if ($chunk < $lastchunk + 1) {
+    if ($next_chunk < $lastchunk + 1) {
       my $new_child = fork();
       if (! $new_child) { # I am child
-        exec("echo $chunk | $aligner_cmd");
+        exec("echo $next_chunk | $aligner_cmd");
         exit 0;
       }
-      $chunk++;
+      $next_chunk++;
       push @children, $new_child;
     }
   }


### PR DESCRIPTION
(quoting @mjpost )
> For alignment, the data is split into chunks of `$ALIGNER_BLOCKSIZE`, and then the aligner (GIZA++ or Berkeley) is run on each of them separately, *in sequence*. Since this is a very time-consuming process, this is hugely wasteful. It would be really nice if the alignments steps, which are embarrassingly parallel, ran in parallel, up to $NUM_THREADS.
> 
> There is some code to use a pool, and some aborted code in there that uses qsub, but I don't want to use multi-node parallelism, just multi-threading. The problem with the thread pool (see commented-out code around line 803 in `pipeline.pl`) is that each thread has to call `system()` to actually run the aligner, and these don't seem to be allowed in parallel (at least, that was my diagnosis). There has to be some way to run these in parallel, however. You could look at Moses and steal its scripts, if needed. In particular, I think a `fork()` model (instead of thread pools) could work well. See `$MOSES/scripts/ems/support/generic-multicore-parallelizer.perl`.

https://trello.com/c/Cv4UQjLM/64-parallelize-alignment