### PR TITLE
Correct ${JOSHUA} variable for kenlm target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,7 +63,7 @@
   </target>
 
   <target name="kenlm" depends="check-joshua-home" description="Build KenLM">
-    <exec executable="./build_kenlm.sh" dir="${env.JOSHUA}/jni" />
+    <exec executable="./build_kenlm.sh" dir="${JOSHUA}/jni" />
   </target>
 
   <target name="giza" depends="check-joshua-home" description="--> 'Make' the giza software in scripts/training/giza-pp/">


### PR DESCRIPTION
Currently build.xml states ${env.JOSHUA} which breaks when you compile with ant all target.
This pull request fixes that.
I noticed this whilst fixing bugs within the Homebrew Formula