### PR TITLE
Fix env.JOSHUA variable assumptions within ivysettings.xml

### DIFF
--- a/lib/ivysettings.xml
+++ b/lib/ivysettings.xml
@@ -9,7 +9,7 @@
       </filesystem>
       <ibiblio name="central" m2compatible="true"/>
       <ibiblio name="tools.gbif.org" m2compatible="true" root="http://tools.gbif.org/maven/repository/" />
-      <packager name="roundup" buildRoot="${env.JOSHUA}/lib/packager/build" resourceCache="${env.JOSHUA}/lib/cache">
+      <packager name="roundup" buildRoot="${JOSHUA}/lib/packager/build" resourceCache="${JOSHUA}/lib/cache">
         <ivy pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/ivy.xml"/>
         <artifact pattern="http://ivyroundup.googlecode.com/svn/trunk/repo/modules/[organisation]/[module]/[revision]/packager.xml"/>
       </packager>


### PR DESCRIPTION
Right now in ivysettings.xml we assume that the user has set a local $JOSHUA e.g. in ~/.bashrc or something.
If this is not the case then the build fails. This is not OK for Homebrew as an installation should not be dependent upon this setting being present. 