### PR TITLE
eclipse target to use class/ for build output as well as removal of kenlm from eclipse definition

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -456,9 +456,9 @@
         <library path="${basedir}/bin" exported="false" />
         <library pathref="eclipse.classpath" exported="false" />
         
-        <source path="${basedir}/src" />
+        <source path="${basedir}/src/joshua" />
 
-        <output path="${basedir}/build" />
+        <output path="${build}" />
       </classpath>
     </eclipse>
   </target>


### PR DESCRIPTION
This PR addresses the final conversation/conversation over on 
https://github.com/joshua-decoder/joshua/pull/220#issuecomment-146187064