### PR TITLE
Packing of multiple grammars using a shared vocabulary

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,6 +25,7 @@
       <include name="junit-4.10.jar" />
       <include name="commons-cli-1.2.jar" />
       <include name="collections-generic-4.01.jar" />
+      <include name="args4j-2.0.29.jar" />
     </fileset>
     <fileset dir="${thraxlib}">
       <include name="thrax.jar" />
@@ -320,7 +321,7 @@
     <property name="ivy.default.ivy.user.dir" value="${JOSHUA}/lib" />
     <ivy:configure file="${JOSHUA}/lib/ivysettings.xml" />
     <ivy:resolve file="${JOSHUA}/lib/ivy.xml" />
-    <ivy:retrieve type="jar" />
+    <ivy:retrieve type="jar,bundle" />
   </target>
 
     <!-- target: clean-eclipse ============================================ -->

--- a/lib/ivy.xml
+++ b/lib/ivy.xml
@@ -10,5 +10,6 @@
     <dependency org="org.testng" name="testng" rev="6.7"/>
     <dependency org="junit"  name="junit" rev="4.10" />
     <dependency org="net.sourceforge.collections" name="collections-generic" rev="4.01"/>
+    <dependency org="args4j" name="args4j" rev="2.0.29" />
   </dependencies>
 </ivy-module>

--- a/scripts/support/grammar-packer.pl
+++ b/scripts/support/grammar-packer.pl
@@ -47,30 +47,28 @@ my $name = basename($grammar);
 my (undef,$sorted_grammar) = tempfile("${name}XXXX", DIR => $opts{T}, UNLINK => 1);
 print STDERR "Sorting grammar to $sorted_grammar...\n" if $opts{v};
 
-# For balanced grammar packing, we need to sort by the complete source side,
-# which is field 1 (for phrase tables not listing the LHS),
-# or field 2 ( conventional Thrax format).
-# For sorting, we temporarily replace the field separator " ||| " with tabs
-# to allow UNIX sort to work correctly with field numbers.
+# We need to sort by source side, which is field 1 (for phrase tables not listing the LHS)
+# or field 2 (convention, Thrax format)
 chomp(my $first_line = `$CAT $grammar | head -n1`);
 if ($first_line =~ /^\[/) {
   # regular grammar
-  if (system("$CAT $grammar | sed 's/ ||| /\t/g' | sort -k2,2 --buffer-size=$opts{m} -T $opts{T} | sed 's/\t/ ||| /g' | gzip -9n > $sorted_grammar")) {
+  if (system("$CAT $grammar | sed 's/ ||| /\t/g' | sort -k2,2 -k3,3 --buffer-size=$opts{m} -T $opts{T} | sed 's/\t/ ||| /g' | gzip -9n > $sorted_grammar")) {
     print STDERR "* FATAL: Couldn't sort the grammar (not enough memory? short on tmp space?)\n";
     exit 2;
   }
 } else {
   # Moses phrase-based grammar -- prepend nonterminal symbol and -log() the weights
-  if (system("$CAT $grammar | $JOSHUA/scripts/support/moses_phrase_to_joshua.pl | sed 's/ ||| /\t/g' | sort -k1,1 --buffer-size=$opts{m} -T $opts{T} | sed 's/\t/ ||| /g' | gzip -9n > $sorted_grammar")) {
+  if (system("$CAT $grammar | $JOSHUA/scripts/support/moses_phrase_to_joshua.pl | sort -k3,3 --buffer-size=$opts{m} -T $opts{T} | gzip -9n > $sorted_grammar")) {
     print STDERR "* FATAL: Couldn't sort the grammar (not enough memory? short on tmp space?)\n";
     exit 2;
   }
-}
+}  
+#my $source_field = ($first_line =~ /^\[/) ? "3,3" : "1,1";
 
 $grammar = $sorted_grammar;
 
 # Do the packing using the config.
-my $cmd = "java -Xmx$opts{m} -cp $JOSHUA/class joshua.tools.GrammarPacker -p $output_dir -g $grammar";
+my $cmd = "java -Xmx$opts{m} -cp $JOSHUA/lib/args4j-2.0.29.jar:$JOSHUA/class joshua.tools.GrammarPackerCli -p $output_dir -g $grammar";
 print STDERR "Packing with $cmd...\n" if $opts{v};
 my $retval = system($cmd);
 

--- a/scripts/training/pipeline.pl
+++ b/scripts/training/pipeline.pl
@@ -1380,7 +1380,7 @@ if ($DO_FILTER_TM and defined $GRAMMAR_FILE and ! $DOING_LATTICES and ! defined 
 if ($OPTIMIZER_RUN == 1 and defined $TUNE_GRAMMAR and $GRAMMAR_TYPE ne "phrase" and $GRAMMAR_TYPE ne "moses") {
   if (! defined $GLUE_GRAMMAR_FILE) {
     $cachepipe->cmd("glue-tune",
-                    "java -Xmx2g -cp $THRAX/lib/hadoop-common-2.5.2.jar:$THRAX/bin/thrax.jar edu.jhu.thrax.util.CreateGlueGrammar $TUNE_GRAMMAR > $DATA_DIRS{tune}/grammar.glue",
+                    "java -Xmx2g -cp $JOSHUA/lib/args4j-2.0.29.jar:$JOSHUA/class joshua.decoder.ff.tm.CreateGlueGrammar -g $TUNE_GRAMMAR > $DATA_DIRS{tune}/grammar.glue",
                     get_file_from_grammar($TUNE_GRAMMAR),
                     "$DATA_DIRS{tune}/grammar.glue");
     $GLUE_GRAMMAR_FILE = "$DATA_DIRS{tune}/grammar.glue";
@@ -1597,7 +1597,7 @@ if ($DO_FILTER_TM and defined $GRAMMAR_FILE and ! $DOING_LATTICES and ! defined 
 if ($OPTIMIZER_RUN == 1 and defined $TEST_GRAMMAR and $GRAMMAR_TYPE ne "phrase" and $GRAMMAR_TYPE ne "moses") {
   if (! defined $GLUE_GRAMMAR_FILE) {
     $cachepipe->cmd("glue-test",
-                    "java -Xmx1g -cp $THRAX/lib/hadoop-common-2.5.2.jar:$THRAX/bin/thrax.jar edu.jhu.thrax.util.CreateGlueGrammar $TEST_GRAMMAR > $DATA_DIRS{test}/grammar.glue",
+                    "java -Xmx2g -cp $JOSHUA/lib/args4j-2.0.29.jar:$JOSHUA/class joshua.decoder.ff.tm.CreateGlueGrammar -g $TEST_GRAMMAR > $DATA_DIRS{test}/grammar.glue",
                     get_file_from_grammar($TEST_GRAMMAR),
                     "$DATA_DIRS{test}/grammar.glue");
     $GLUE_GRAMMAR_FILE = "$DATA_DIRS{test}/grammar.glue";

--- a/src/joshua/corpus/Vocabulary.java
+++ b/src/joshua/corpus/Vocabulary.java
@@ -67,9 +67,8 @@ public class Vocabulary {
    * @return Returns true if vocabulary was read without mismatches or collisions.
    * @throws IOException
    */
-  public static boolean read(String file_name) throws IOException {
+  public static boolean read(final File vocab_file) throws IOException {
     synchronized (lock) {
-      File vocab_file = new File(file_name);
       DataInputStream vocab_stream =
           new DataInputStream(new BufferedInputStream(new FileInputStream(vocab_file)));
       int size = vocab_stream.readInt();

--- a/src/joshua/decoder/JoshuaConfiguration.java
+++ b/src/joshua/decoder/JoshuaConfiguration.java
@@ -1,5 +1,8 @@
 package joshua.decoder;
 
+import static joshua.util.FormatUtils.cleanNonTerminal;
+import static joshua.util.FormatUtils.markup;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -438,11 +441,11 @@ public class JoshuaConfiguration {
             lattice_decoding = true;
 
           } else if (parameter.equals(normalize_key("default-non-terminal"))) {
-            default_non_terminal = String.format("[%s]", FormatUtils.cleanNonterminal(fds[1].trim()));
+            default_non_terminal = markup(cleanNonTerminal(fds[1].trim()));
             logger.finest(String.format("default_non_terminal: %s", default_non_terminal));
 
           } else if (parameter.equals(normalize_key("goal-symbol"))) {
-            goal_symbol = String.format("[%s]", FormatUtils.cleanNonterminal(fds[1].trim()));
+            goal_symbol = markup(cleanNonTerminal(fds[1].trim()));
             logger.finest("goalSymbol: " + goal_symbol);
 
           } else if (parameter.equals(normalize_key("weights-file"))) {

--- a/src/joshua/decoder/ff/tm/CreateGlueGrammar.java
+++ b/src/joshua/decoder/ff/tm/CreateGlueGrammar.java
@@ -1,0 +1,110 @@
+package joshua.decoder.ff.tm;
+
+import static joshua.decoder.ff.tm.packed.PackedGrammar.VOCABULARY_FILENAME;
+import static joshua.util.FormatUtils.cleanNonTerminal;
+import static joshua.util.FormatUtils.isNonterminal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import joshua.corpus.Vocabulary;
+import joshua.decoder.JoshuaConfiguration;
+import joshua.util.io.LineReader;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+
+public class CreateGlueGrammar {
+  
+  
+  private final Set<String> nonTerminalSymbols = new HashSet<>();
+  private static final Logger log = Logger.getLogger(CreateGlueGrammar.class.getName());
+  
+  @Option(name = "--grammar", aliases = {"-g"}, required = true, usage = "provide grammar to determine list of NonTerminal symbols.")
+  private String grammarPath;
+  
+  @Option(name = "--goal", aliases = {"-goal"}, required = false, usage = "specify custom GOAL symbol. Default: 'GOAL'")
+  private String goalSymbol = cleanNonTerminal(new JoshuaConfiguration().goal_symbol);
+
+  /* Rule templates */
+  // [GOAL] ||| <s> ||| <s> ||| 0
+  private static final String R_START = "[%1$s] ||| <s> ||| <s> ||| 0";
+  // [GOAL] ||| [GOAL,1] [X,2] ||| [GOAL,1] [X,2] ||| -1
+  private static final String R_TWO = "[%1$s] ||| [%1$s,1] [%2$s,2] ||| [%1$s,1] [%2$s,2] ||| -1";
+  // [GOAL] ||| [GOAL,1] </s> ||| [GOAL,1] </s> ||| 0
+  private static final String R_END = "[%1$s] ||| [%1$s,1] </s> ||| [%1$s,1] </s> ||| 0";
+  // [GOAL] ||| <s> [X,1] </s> ||| <s> [X,1] </s> ||| 0
+  private static final String R_TOP = "[%1$s] ||| <s> [%2$s,1] </s> ||| <s> [%2$s,1] </s> ||| 0";
+  
+  private void run() throws IOException {
+    
+    File grammar_file = new File(grammarPath);
+    if (!grammar_file.exists()) {
+      throw new IOException("Grammar file doesn't exist: " + grammarPath);
+    }
+
+    // in case of a packedGrammar, we read the serialized vocabulary,
+    // collecting all cleaned nonTerminal symbols.
+    if (grammar_file.isDirectory()) {
+      Vocabulary.read(grammarPath + File.separator + VOCABULARY_FILENAME);
+      for (int i = 0; i < Vocabulary.size(); ++i) {
+        final String token = Vocabulary.word(i);
+        if (isNonterminal(token)) {
+          nonTerminalSymbols.add(cleanNonTerminal(token));
+        }
+      }
+    // otherwise we collect cleaned left-hand sides from the rules in the text grammar.
+    } else { 
+      final LineReader reader = new LineReader(grammarPath);
+      while (reader.hasNext()) {
+        final String line = reader.next();
+        int lhsStart = line.indexOf("[") + 1;
+        int lhsEnd = line.indexOf("]");
+        if (lhsStart < 1 || lhsEnd < 0) {
+          log.info(String.format("malformed rule: %s\n", line));
+          continue;
+        }
+        final String lhs = line.substring(lhsStart, lhsEnd);
+        System.err.println(lhs);
+        nonTerminalSymbols.add(lhs);
+      }
+    }
+    
+    log.info(
+        String.format("%d nonTerminal symbols read: %s",
+        nonTerminalSymbols.size(),
+        nonTerminalSymbols.toString()));
+
+    // write glue rules to stdout
+    
+    System.out.println(String.format(R_START, goalSymbol));
+    
+    for (String nt : nonTerminalSymbols)
+      System.out.println(String.format(R_TWO, goalSymbol, nt));
+    
+    System.out.println(String.format(R_END, goalSymbol));
+    
+    for (String nt : nonTerminalSymbols)
+      System.out.println(String.format(R_TOP, goalSymbol, nt));
+
+  }
+  
+  public static void main(String[] args) throws IOException {
+    final CreateGlueGrammar glueCreator = new CreateGlueGrammar();
+    final CmdLineParser parser = new CmdLineParser(glueCreator);
+
+    try {
+      parser.parseArgument(args);
+      glueCreator.run();
+    } catch (CmdLineException e) {
+      log.info(e.toString());
+      parser.printUsage(System.err);
+      System.exit(1);
+    }
+   }
+}

--- a/src/joshua/decoder/ff/tm/CreateGlueGrammar.java
+++ b/src/joshua/decoder/ff/tm/CreateGlueGrammar.java
@@ -51,7 +51,7 @@ public class CreateGlueGrammar {
     // in case of a packedGrammar, we read the serialized vocabulary,
     // collecting all cleaned nonTerminal symbols.
     if (grammar_file.isDirectory()) {
-      Vocabulary.read(grammarPath + File.separator + VOCABULARY_FILENAME);
+      Vocabulary.read(new File(grammarPath + File.separator + VOCABULARY_FILENAME));
       for (int i = 0; i < Vocabulary.size(); ++i) {
         final String token = Vocabulary.word(i);
         if (isNonterminal(token)) {

--- a/src/joshua/decoder/ff/tm/hash_based/MemoryBasedBatchGrammar.java
+++ b/src/joshua/decoder/ff/tm/hash_based/MemoryBasedBatchGrammar.java
@@ -275,8 +275,8 @@ public class MemoryBasedBatchGrammar extends AbstractGrammar {
   public void addGlueRules(ArrayList<FeatureFunction> featureFunctions) {
     HieroFormatReader reader = new HieroFormatReader();
 
-    String goalNT = FormatUtils.cleanNonterminal(joshuaConfiguration.goal_symbol);
-    String defaultNT = FormatUtils.cleanNonterminal(joshuaConfiguration.default_non_terminal);
+    String goalNT = FormatUtils.cleanNonTerminal(joshuaConfiguration.goal_symbol);
+    String defaultNT = FormatUtils.cleanNonTerminal(joshuaConfiguration.default_non_terminal);
 
     String[] ruleStrings = new String[] {
         String.format("[%s] ||| %s ||| %s ||| 0", goalNT, Vocabulary.START_SYM,

--- a/src/joshua/decoder/ff/tm/packed/PackedGrammar.java
+++ b/src/joshua/decoder/ff/tm/packed/PackedGrammar.java
@@ -80,6 +80,8 @@ public class PackedGrammar extends AbstractGrammar {
   private PackedRoot root;
   private ArrayList<PackedSlice> slices;
 
+  public static final String VOCABULARY_FILENAME = "vocabulary";
+
   // The grammar specification keyword (e.g., "thrax" or "moses")
   private String type;
 
@@ -90,7 +92,7 @@ public class PackedGrammar extends AbstractGrammar {
     this.type = type;
 
     // Read the vocabulary.
-    String vocabFile = grammar_dir + File.separator + "vocabulary";
+    String vocabFile = grammar_dir + File.separator + VOCABULARY_FILENAME;
     Decoder.LOG(1, String.format("Reading vocabulary: %s", vocabFile));
     if (!Vocabulary.read(vocabFile)) {
       throw new RuntimeException("mismatches or collisions while reading on-disk vocabulary");

--- a/src/joshua/tools/GrammarPackerCli.java
+++ b/src/joshua/tools/GrammarPackerCli.java
@@ -1,0 +1,137 @@
+package joshua.tools;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+public class GrammarPackerCli {
+  
+  private static final Logger log = Logger.getLogger(GrammarPackerCli.class.getName());
+
+  // Input grammars to be packed (with a joint vocabulary)
+  @Option(name = "--grammars", aliases = {"-g", "-i"}, handler = StringArrayOptionHandler.class, required = true, usage = "list of grammars to pack (jointly, i.e. they share the same vocabulary)")
+  private List<String> grammars = new ArrayList<>();
+  
+  // Output grammars
+  @Option(name = "--outputs", aliases = {"-p", "-o"}, handler = StringArrayOptionHandler.class, required = true, usage = "output directories of packed grammars.")
+  private List<String> outputs = new ArrayList<>();
+  
+  // Output grammars
+  @Option(name = "--alignments", aliases = {"-a", "--fa"}, handler = StringArrayOptionHandler.class, required = false, usage = "alignment files")
+  private List<String> alignments_filenames = new ArrayList<>();
+  
+  // Config filename
+  @Option(name = "--config_file", aliases = {"-c"}, required = false, usage = "(optional) packing configuration file")
+  private String config_filename;
+  
+  @Option(name = "--dump_files", aliases = {"-d"}, handler = StringArrayOptionHandler.class, usage = "(optional) dump feature stats to file")
+  private List<String> featuredump_filenames = new ArrayList<>();
+  
+  @Option(name = "--ga", usage = "whether alignments are present in the grammar")
+  private boolean grammar_alignments = false;
+  
+  @Option(name = "--slice_size", aliases = {"-s"}, required = false, usage = "approximate slice size in # of rules (default=1000000)")
+  private int slice_size = 1000000;
+  
+  
+  private void run() throws IOException {
+
+    final List<String> missingFilenames = new ArrayList<>(grammars.size());
+    for (final String g : grammars) {
+      if (!new File(g).exists()) {
+        missingFilenames.add(g);
+      }
+    }
+    if (!missingFilenames.isEmpty()) {
+      throw new IOException("Input grammar files not found: " + missingFilenames.toString());
+    }
+    
+    if (config_filename != null && !new File(config_filename).exists()) {
+      throw new IOException("Config file not found: " + config_filename);
+    }
+
+    if (!outputs.isEmpty()) {
+      if (outputs.size() != grammars.size()) {
+        throw new IOException("Must provide an output directory for each grammar");
+      }
+      final List<String> existingOutputs = new ArrayList<>(outputs.size());
+      for (final String o : outputs) {
+        if (new File(o).exists()) {
+          existingOutputs.add(o);
+        }
+      }
+      if (!existingOutputs.isEmpty()) {
+        throw new IOException("These output directories already exist (will not overwrite): " + existingOutputs.toString());
+      }
+    }
+    if (outputs.isEmpty()) {
+      for (final String g : grammars) {
+        outputs.add(g + ".packed");
+      }
+    }
+    
+    if (!alignments_filenames.isEmpty()) {
+      final List<String> missingAlignmentFiles = new ArrayList<>(alignments_filenames.size());
+      for (final String a : alignments_filenames) {
+        if (!new File(a).exists()) {
+          missingAlignmentFiles.add(a);
+        }
+      }
+      if (!missingAlignmentFiles.isEmpty()) {
+        throw new IOException("Alignment files not found: " + missingAlignmentFiles.toString());
+      }
+    }
+
+    // create Packer instances for each grammar
+    final List<GrammarPacker> packers = new ArrayList<>(grammars.size());
+    for (int i = 0; i < grammars.size(); i++) {
+      log.info("Starting GrammarPacker for " + grammars.get(i));
+      final String alignment_filename = alignments_filenames.isEmpty() ? null : alignments_filenames.get(i);
+      final String featuredump_filename = featuredump_filenames.isEmpty() ? null : featuredump_filenames.get(i);
+      final GrammarPacker packer = new GrammarPacker(
+          grammars.get(i),
+          config_filename,
+          outputs.get(i),
+          alignment_filename,
+          featuredump_filename,
+          grammar_alignments,
+          slice_size);
+      packers.add(packer);
+    }
+    
+    // run all packers in sequence, accumulating vocabulary items
+    for (final GrammarPacker packer : packers) {
+      log.info("Starting GrammarPacker for " + packer.getGrammar());
+      packer.pack();
+      log.info("PackedGrammar located at " + packer.getOutputDirectory());
+    }
+    
+    // for each packed grammar, overwrite the internally serialized vocabulary with the current global one.
+    for (final GrammarPacker packer : packers) {
+      log.info("Writing final common Vocabulary to " + packer.getOutputDirectory());
+      packer.writeVocabulary();
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    final GrammarPackerCli cli = new GrammarPackerCli();
+    final CmdLineParser parser = new CmdLineParser(cli);
+
+    try {
+      parser.parseArgument(args);
+      cli.run();
+    } catch (CmdLineException e) {
+      log.info(e.toString());
+      parser.printUsage(System.err);
+      System.exit(1);
+    }
+  }
+
+}

--- a/src/joshua/util/FormatUtils.java
+++ b/src/joshua/util/FormatUtils.java
@@ -2,8 +2,6 @@ package joshua.util;
 
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -13,12 +11,8 @@ import java.util.regex.Pattern;
  * @author Lane Schwartz
  */
 public class FormatUtils {
-
-  private static Map<String, String> cache;
-
-  static {
-    cache = new HashMap<String, String>();
-  }
+  
+  private static final String INDEX_SEPARATOR = ",";
 
   /**
    * Determines whether the string is a nonterminal by checking that the first character is [
@@ -34,31 +28,38 @@ public class FormatUtils {
   /**
    * Nonterminals are stored in the vocabulary in square brackets. This removes them when you 
    * just want the raw nonterminal word.
+   * Supports indexed and non-indexed nonTerminals:
+   * [GOAL] -> GOAL
+   * [X,1] -> [X]
    * 
    * @param nt the nonterminal, e.g., "[GOAL]"
    * @return the cleaned nonterminal, e.g., "GOAL"
    */
-  public static String cleanNonterminal(String nt) {
-    if (isNonterminal(nt))
+  public static String cleanNonTerminal(String nt) {
+    if (isNonterminal(nt)) {
+      if (isIndexedNonTerminal(nt)) {
+        // strip ",.*]"
+        return nt.substring(1, nt.indexOf(INDEX_SEPARATOR));
+      }
+      // strip "]"
       return nt.substring(1, nt.length() - 1);
+    }
     return nt;
   }
-
-  public static String cleanIndexedNonterminal(String nt) {
-    return nt.substring(1, nt.length() - 3);
+  
+  private static boolean isIndexedNonTerminal(String nt) {
+    return nt.contains(INDEX_SEPARATOR);
   }
 
-  public static String stripNt(String nt) {
-    String stripped = cache.get(nt);
-    if (stripped == null) {
-      stripped = markup(cleanIndexedNonterminal(nt));
-      cache.put(nt, stripped);
-    }
-    return stripped;
+  /**
+   * Removes the index from a nonTerminal: [X,1] -> [X].
+   */
+  public static String stripNonTerminalIndex(String nt) {
+    return markup(cleanNonTerminal(nt));
   }
 
   public static int getNonterminalIndex(String nt) {
-    return Integer.parseInt(nt.substring(nt.length() - 2, nt.length() - 1));
+    return Integer.parseInt(nt.substring(nt.indexOf(INDEX_SEPARATOR) + 1, nt.length() - 1));
   }
 
   /**
@@ -75,7 +76,7 @@ public class FormatUtils {
   }
 
   public static String markup(String nt, int index) {
-    return "[" + nt + "," + index + "]";
+    return "[" + nt + INDEX_SEPARATOR + index + "]";
   }
 
   /**

--- a/test/packed-grammar/joshua.config
+++ b/test/packed-grammar/joshua.config
@@ -1,6 +1,6 @@
 lm = kenlm 5 false false 100 lm.gz
-tm = packed pt 12 grammar.packed
-tm = thrax glue -1 grammar.glue
+tm = thrax -owner pt -maxspan 12 -path grammar.packed
+tm = thrax -owner glue -maxspan -1 -path grammar.glue
 
 mark_oovs=false
 

--- a/test/packed-grammar/test.sh
+++ b/test/packed-grammar/test.sh
@@ -2,14 +2,12 @@
 
 set -u
 
-export THRAX=$JOSHUA/thrax
-
 # pack the grammar
 rm -rf grammar.packed
 $JOSHUA/scripts/support/grammar-packer.pl grammar.gz grammar.packed 2> packer.log
 
 # generate the glue grammar
-java -Xmx2g -cp $THRAX/lib/hadoop-common-2.5.2.jar:$THRAX/bin/thrax.jar edu.jhu.thrax.util.CreateGlueGrammar grammar.packed > grammar.glue 2> glue.log
+java -Xmx2g -cp $JOSHUA/lib/args4j-2.0.29.jar:$JOSHUA/class joshua.decoder.ff.tm.CreateGlueGrammar -g grammar.packed > grammar.glue 2> glue.log
 
 # decode
 cat input.bn | $JOSHUA/bin/joshua-decoder -m 1g -threads 2 -c joshua.config > output 2> log
@@ -17,7 +15,7 @@ cat input.bn | $JOSHUA/bin/joshua-decoder -m 1g -threads 2 -c joshua.config > ou
 diff -u output output.gold > diff
 
 if [ $? -eq 0 ]; then
-	rm -f packer.log diff log output.bleu output grammar.glue glue.log
+	#rm -f packer.log diff log output.bleu output grammar.glue glue.log
 	rm -rf grammar.packed
 	exit 0
 else


### PR DESCRIPTION
This enables the use of multiple packed grammars in the joshua.config. Also moved CreateGlueGrammar tool to Joshua and cleaned it a bit.

The change includes some cleaning of FormatUtils, a new GrammarPackerCli class to decouple packing from the Cli code. The CLI supports multiple input grammars to pack, which is not yet supported by grammar-packer.pl. Someone with more perl knowledge can probably make this efficient. Packed Grammars that need to be used jointly during decoding, need to be packed jointly in one call of GrammarPackerCli.