### PR TITLE
Fixed decoder/k-best-extraction and phrase/unique-hypotheses tests for Java 8

### DIFF
--- a/src/joshua/decoder/chart_parser/Cell.java
+++ b/src/joshua/decoder/chart_parser/Cell.java
@@ -3,6 +3,7 @@ package joshua.decoder.chart_parser;
 import java.util.ArrayList;	
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +32,7 @@ class Cell {
   private int goalSymbol;
 
   // to maintain uniqueness of nodes
-  private HashMap<HGNode.Signature, HGNode> nodesSigTbl = new HashMap<HGNode.Signature, HGNode>();
+  private HashMap<HGNode.Signature, HGNode> nodesSigTbl = new LinkedHashMap<HGNode.Signature, HGNode>();
 
   // signature by lhs
   private Map<Integer, SuperNode> superNodesTbl = new HashMap<Integer, SuperNode>();

--- a/src/joshua/decoder/hypergraph/KBestExtractor.java
+++ b/src/joshua/decoder/hypergraph/KBestExtractor.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -426,7 +427,7 @@ public class KBestExtractor {
      */
     private void getCandidates(KBestExtractor kbestExtractor) {
       /* The list of candidates extending from this (virtual) node. */
-      candHeap = new PriorityQueue<DerivationState>();
+      candHeap = new PriorityQueue<DerivationState>(new DerivationStateComparator());
 
       /*
        * When exploring the cube frontier, there are multiple paths to each candidate. For example,
@@ -475,7 +476,7 @@ public class KBestExtractor {
       // TODO: if tem.size is too large, this may cause unnecessary computation, we comment the
       // segment to accommodate the unique nbest extraction
       /*
-       * if(tem.size()>global_n){ heap_cands=new PriorityQueue<DerivationState>(); for(int i=1;
+       * if(tem.size()>global_n){ heap_cands=new PriorityQueue<DerivationState>(new DerivationStateComparator()); for(int i=1;
        * i<=global_n; i++) heap_cands.add(tem.poll()); }else heap_cands=tem;
        */
     }
@@ -537,7 +538,7 @@ public class KBestExtractor {
    */
 
   // each DerivationState roughly corresponds to a hypothesis
-  public class DerivationState implements Comparable<DerivationState> {
+  public class DerivationState {
     /* The edge ("e" in the paper) */
     public HyperEdge edge;
 
@@ -741,17 +742,20 @@ public class KBestExtractor {
       return virtualChild.nbests.get(ranks[tailNodeIndex] - 1);
     }
 
+  } // end of Class DerivationState
+
+  public static class DerivationStateComparator implements Comparator<DerivationState> {
     // natural order by cost
-    public int compareTo(DerivationState another) {
-      if (this.getCost() > another.getCost()) {
+    public int compare(DerivationState one, DerivationState another) {
+      if (one.getCost() > another.getCost()) {
         return -1;
-      } else if (this.getCost() == another.getCost()) {
+      } else if (one.getCost() == another.getCost()) {
         return 0;
       } else {
         return 1;
       }
     }
-  } // end of Class DerivationState
+  }
 
   /**
    * This interface provides a generic way to do things at each stage of a derivation. The

--- a/src/joshua/decoder/phrase/Candidate.java
+++ b/src/joshua/decoder/phrase/Candidate.java
@@ -16,7 +16,7 @@ import joshua.decoder.ff.state_maintenance.DPState;
 import joshua.decoder.ff.tm.Rule;
 import joshua.decoder.hypergraph.HGNode;
 
-public class Candidate implements Comparable<Candidate> {
+public class Candidate {
 
   // the set of hypotheses that can be paired with phrases from this span 
   private List<Hypothesis> hypotheses;
@@ -131,11 +131,6 @@ public class Candidate implements Comparable<Candidate> {
     return null;
   }
   
-  @Override
-  public int compareTo(Candidate other) {
-    return Float.compare(other.score(), score());
-  }
-
   /**
    * Returns the input span from which the phrases for this candidates were gathered.
    * 

--- a/src/joshua/decoder/phrase/CandidateComparator.java
+++ b/src/joshua/decoder/phrase/CandidateComparator.java
@@ -1,0 +1,10 @@
+package joshua.decoder.phrase;
+
+import java.util.Comparator;
+
+public class CandidateComparator implements Comparator<Candidate> {
+  @Override
+  public int compare(Candidate one, Candidate another) {
+    return Float.compare(another.score(), one.score());
+  }
+}

--- a/src/joshua/decoder/phrase/Stack.java
+++ b/src/joshua/decoder/phrase/Stack.java
@@ -49,7 +49,7 @@ public class Stack extends ArrayList<Hypothesis> {
     this.sentence = sentence;
     this.config = config;
     
-    this.candidates = new PriorityQueue<Candidate>(1);
+    this.candidates = new PriorityQueue<Candidate>(1, new CandidateComparator());
     this.coverages = new HashMap<Coverage, ArrayList<Hypothesis>>();
     this.visitedStates = new HashSet<Candidate>();
     this.deduper = new HashMap<Hypothesis,Hypothesis>();

--- a/test/lattice-short/joshua.config
+++ b/test/lattice-short/joshua.config
@@ -14,7 +14,7 @@ pop-limit = 100
 #nbest config
 use_unique_nbest = true 
 include-align-index = false
-top-n = 5
+top-n = 6
 
 lattice-decoding = true
 

--- a/test/lattice-short/output.expected
+++ b/test/lattice-short/output.expected
@@ -14,4 +14,5 @@
 4 ||| A x ||| tm_pt_0=-1.000 tm_glue_0=2.000 lm_0=-101.827 OOVPenalty=-100.000 WordPenalty=-1.737 SourcePath=2.000 ||| -199.090
 4 ||| B X ||| tm_pt_0=-5.000 tm_glue_0=2.000 lm_0=-200.681 OOVPenalty=0.000 WordPenalty=-1.737 SourcePath=2.000 ||| -201.944
 4 ||| B x ||| tm_pt_0=-2.000 tm_glue_0=2.000 lm_0=-200.681 OOVPenalty=-100.000 WordPenalty=-1.737 SourcePath=2.000 ||| -298.944
+4 ||| a X ||| tm_pt_0=-3.000 tm_glue_0=2.000 lm_0=-200.681 OOVPenalty=-100.000 WordPenalty=-1.737 SourcePath=2.000 ||| -299.944
 4 ||| b X ||| tm_pt_0=-3.000 tm_glue_0=2.000 lm_0=-200.681 OOVPenalty=-100.000 WordPenalty=-1.737 SourcePath=2.000 ||| -299.944


### PR DESCRIPTION
We narrowed down the issue with these two tests to a change in Java 8's HashMap implementation.  The new HashMap uses red-black trees instead of lists for contended buckets. Because of this change, classes that implement the Comparable interface are treated slightly differently by HashMaps. This can potentially corrupt the HashMap's contents (especially with large HashMaps).  

Pulling out comparison logic to a separate Comparator class mitigates the issue.