### PR TITLE
Attempted removal of kenlm from Eclipse project 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -342,6 +342,14 @@
     </fileset>
   </path>
   
+  <!-- classpath for generating eclipse project -->
+  <path id="eclipse.source.classpath">
+    <fileset dir="${basedir}/src/">
+      <include name="**/*.java" />
+      <exclude name="${basedir}/src/kenlm" />
+    </fileset>
+  </path>
+  
   <!-- target: ant-eclipse-download   =================================== -->
   <target name="ant-eclipse-download" description="--> Downloads the ant-eclipse binary.">
     <get src="http://downloads.sourceforge.net/project/ant-eclipse/ant-eclipse/1.0/ant-eclipse-1.0.bin.tar.bz2"
@@ -374,11 +382,11 @@
       <project name="${eclipse.project}" />
       <classpath>
         <library pathref="eclipse.classpath" exported="false" />
-        <source path="${basedir}/src" />
+        <source path="${basedir}/src" excluding="${basedir}/src/kenlm | ${basedir}/src/joshua/decoder/ff/lm/kenlm" />
         <output path="${build}" />
       </classpath>
     </eclipse>
   </target>
-
+  
 </project>
 

--- a/build.xml
+++ b/build.xml
@@ -342,14 +342,6 @@
     </fileset>
   </path>
   
-  <!-- classpath for generating eclipse project -->
-  <path id="eclipse.source.classpath">
-    <fileset dir="${basedir}/src/">
-      <include name="**/*.java" />
-      <exclude name="${basedir}/src/kenlm" />
-    </fileset>
-  </path>
-  
   <!-- target: ant-eclipse-download   =================================== -->
   <target name="ant-eclipse-download" description="--> Downloads the ant-eclipse binary.">
     <get src="http://downloads.sourceforge.net/project/ant-eclipse/ant-eclipse/1.0/ant-eclipse-1.0.bin.tar.bz2"


### PR DESCRIPTION
Hi @mjpost,
I've put a bit of time into this with no luck.
As per the Ant-Eclipse documentation, the _excluding_ parameter should remove the offending directories from the Eclipse project classpath however I can't seem to get this working.
FYI, the documentation I am referring to can be found below
http://ant-eclipse.sourceforge.net/ant-eclipse.html
IMHO, although this is not perfect, the inclusion of the offending kenlm directories within the Eclipse project is not anything wrong! It is annoying I agree, but it is harmless really. 