### PR TITLE
Add Dockerfile for Arabic-English language pack

### DIFF
--- a/examples/docker/ar-en-phrase/Dockerfile
+++ b/examples/docker/ar-en-phrase/Dockerfile
@@ -1,0 +1,11 @@
+FROM joshua
+
+ENV language_pack=ar-en-phrase
+
+RUN mkdir /opt/$language_pack
+WORKDIR /opt/$language_pack
+
+RUN curl http://cs.jhu.edu/~post/language-packs/language-pack-ar-en-phrase-2015-03-18.tgz \
+    | tar xz --strip-components=1
+
+ENTRYPOINT ["./run-joshua.sh"]


### PR DESCRIPTION
This change adds a Dockerfile to build an image for Arabic to English
translation. The Dockerfile assumes that a base 'joshua' image already
exists and downloads the language package from online.