### PR TITLE
Add Dockerfile for Chinese-English language pack

### DIFF
--- a/examples/docker/zh-en-hiero/Dockerfile
+++ b/examples/docker/zh-en-hiero/Dockerfile
@@ -1,0 +1,11 @@
+FROM joshua
+
+ENV language_pack=zh-en-hiero
+
+RUN mkdir /opt/$language_pack
+WORKDIR /opt/$language_pack
+
+RUN curl http://cs.jhu.edu/~post/language-packs/zh-en-hiero-2016-01-13.tgz \
+    | tar xz --strip-components=1
+
+ENTRYPOINT ["./run-joshua.sh"]


### PR DESCRIPTION
This change adds a Dockerfile to build an image for Chinese to English
translation. The Dockerfile assumes that a base 'joshua' image already
exists and downloads the language package from online.